### PR TITLE
Fix Firefox dash keyCode mapping.

### DIFF
--- a/src/trackCharacters.js
+++ b/src/trackCharacters.js
@@ -5,6 +5,7 @@
 const characterMapping = {
   106: '*',
   110: '.',
+  173: '-',
   189: '-',
   190: '.',
   'shift': {


### PR DESCRIPTION
Fix Firefox '-' keyCode mapping as Firefox having different values. 
https://github.com/ccampbell/mousetrap/pull/215
