### PR TITLE
Add support for draft-js v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+
+* Added support for draft-js v0.11.0
+
 # v2.0.0 2017-06-19
 
 * Update to match [method signature changes in draft-js v0.10.1](https://github.com/draft-js-plugins/draft-js-plugins/issues/736)

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,11 +130,12 @@ function autoListPlugin() {
      * Handle our custom `commands`
      * @param  {String} command The current command to respond to
      * @param  {Object} editorState Current editor state
+     * @param  {Number} eventTimeStamp When the event happened.
      * @param  {Function} options.setEditorState Setter function passed by
      * the draft-js-plugin-editor
      * @return {String} Did we handle the return or not?
      */
-    handleKeyCommand: function handleKeyCommand(command, editorState, _ref2) {
+    handleKeyCommand: function handleKeyCommand(command, editorState, eventTimeStamp, _ref2) {
       var setEditorState = _ref2.setEditorState;
 
       if (command === commands.UL || command === commands.OL) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/icelab/draft-js-autolist-plugin",
   "peerDependencies": {
-    "draft-js": ">=0.10.1"
+    "draft-js": "^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "6.7.5",

--- a/src/index.js
+++ b/src/index.js
@@ -114,11 +114,12 @@ function autoListPlugin () {
      * Handle our custom `commands`
      * @param  {String} command The current command to respond to
      * @param  {Object} editorState Current editor state
+     * @param  {Number} eventTimeStamp When the event happened.
      * @param  {Function} options.setEditorState Setter function passed by
      * the draft-js-plugin-editor
      * @return {String} Did we handle the return or not?
      */
-    handleKeyCommand (command, editorState, { setEditorState }) {
+    handleKeyCommand (command, editorState, eventTimeStamp, { setEditorState }) {
       if (command === commands.UL || command === commands.OL) {
         // Set up the base types/checks
         let listType = blockTypes.UL


### PR DESCRIPTION
Fixes #16 

@makenosound A function signature changed. I've tested this in an app of mine along with draft-js-plugins-editor@3.0.0 and it works.

Please note that this is a breaking change and thus we should update the major version.

I've noticed that the built files are also in the repository, therefore I added them to the PR.