### PR TITLE
Use event.key instead of event.keyCode to support non-english users

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,25 +40,24 @@ var blockTypes = {
   UL: 'unordered-list-item',
   OL: 'ordered-list-item',
   UNSTYLED: 'unstyled'
-};
 
-/**
- * Auto-list Plugin
- *
- * Infers that the user is trying to write a list of things and turns the
- * current block into either an ordered or unordered list.
- *
- * We do this by tracking the characters typed and, when a matching sequence
- * is entered, then attempting to turn it into the correct list type.
- *
- * This approach is not fool-proof: if you make a mistake while typing a list
- * and have to delete it we’ll fail to infer that correctly. This is somewhat
- * intentional as we don't want to have to query the content of the editor
- * for every single keyDown.
- *
- * @return {Object} Object defining the draft-js API methods
- */
-function autoListPlugin() {
+  /**
+   * Auto-list Plugin
+   *
+   * Infers that the user is trying to write a list of things and turns the
+   * current block into either an ordered or unordered list.
+   *
+   * We do this by tracking the characters typed and, when a matching sequence
+   * is entered, then attempting to turn it into the correct list type.
+   *
+   * This approach is not fool-proof: if you make a mistake while typing a list
+   * and have to delete it we’ll fail to infer that correctly. This is somewhat
+   * intentional as we don't want to have to query the content of the editor
+   * for every single keyDown.
+   *
+   * @return {Object} Object defining the draft-js API methods
+   */
+};function autoListPlugin() {
   var keyCharsHistory = [];
 
   return {
@@ -71,7 +70,6 @@ function autoListPlugin() {
      * @param  {KeyboardEvent} e Synthetic keyboard event from draftjs
      * @return {String} A command, either our custom ones or one of the defaults
      */
-
     keyBindingFn: function keyBindingFn(e) {
       keyCharsHistory = (0, _trackCharacters2.default)(keyCharsHistory, e);
 
@@ -86,8 +84,8 @@ function autoListPlugin() {
           // Test the all the characters to see if they match the full ordered
           // list regex
         } else if (OL_FULL_REGEX.test(keyCharsHistory.join(''))) {
-            return commands.OL;
-          }
+          return commands.OL;
+        }
       }
     },
 

--- a/lib/trackCharacters.js
+++ b/lib/trackCharacters.js
@@ -1,24 +1,8 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-/**
- * A mapping of keycodes to output characters that relate to list making
- * @type {Object}
- */
-var characterMapping = {
-  106: '*',
-  110: '.',
-  189: '-',
-  190: '.',
-  'shift': {
-    56: '*',
-    221: '*',
-    190: '.'
-  }
-};
-
 /**
  * Track the characters generated from keyboard input
  * @param  {Array} history List of (max 3) characters
@@ -26,10 +10,9 @@ var characterMapping = {
  * @return {Array} The adjusted history
  */
 function trackCharacters() {
-  var history = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
+  var history = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
   var e = arguments[1];
-  var keyCode = e.keyCode;
-  var shiftKey = e.shiftKey;
+  var key = e.key;
 
   // Keep history to <= 3 items because we only need that much to determine
   // whether a list is being indicated
@@ -40,12 +23,7 @@ function trackCharacters() {
     history = history.slice();
   }
 
-  // Map the keyCodes to characters we care about
-  var character = shiftKey ? characterMapping.shift[keyCode] : characterMapping[keyCode];
-  if (!character) {
-    character = String.fromCharCode(keyCode);
-  }
-  history.push(character);
+  history.push(key);
   return history;
 }
 

--- a/src/trackCharacters.js
+++ b/src/trackCharacters.js
@@ -1,27 +1,11 @@
 /**
- * A mapping of keycodes to output characters that relate to list making
- * @type {Object}
- */
-const characterMapping = {
-  106: '*',
-  110: '.',
-  189: '-',
-  190: '.',
-  'shift': {
-    56: '*',
-    221: '*',
-    190: '.',
-  },
-}
-
-/**
  * Track the characters generated from keyboard input
  * @param  {Array} history List of (max 3) characters
  * @param  {KeyDownEvent} e Synthetic keyboard event from draftjs' `keyBindingFn`
  * @return {Array} The adjusted history
  */
 function trackCharacters (history = [], e) {
-  const {keyCode, shiftKey} = e
+  const {key} = e
 
   // Keep history to <= 3 items because we only need that much to determine
   // whether a list is being indicated
@@ -31,12 +15,7 @@ function trackCharacters (history = [], e) {
     history = history.slice()
   }
 
-  // Map the keyCodes to characters we care about
-  let character = (shiftKey) ? characterMapping.shift[keyCode] : characterMapping[keyCode]
-  if (!character) {
-    character = String.fromCharCode(keyCode)
-  }
-  history.push(character)
+  history.push(key)
   return history
 }
 


### PR DESCRIPTION
Using event.keyCode for history works only for the english keyboard layout. The problem is with the dot char `.`
In some keyboard layouts it is not 190. For example, in cyrilic layout it is 191 and so on in other layouts.
My proposal to use event.key to get the real character instead of using event.keyCode.